### PR TITLE
Revert "chore(deps-dev): bump rollup from 4.9.1 to 4.22.4 in /packages/paypal-js in the npm_and_yarn group across 1 directory"

### DIFF
--- a/packages/paypal-js/package.json
+++ b/packages/paypal-js/package.json
@@ -67,7 +67,7 @@
         "jsdom": "^23.0.1",
         "lint-staged": "15.2.0",
         "openapi-typescript": "^6.7.3",
-        "rollup": "4.22.4",
+        "rollup": "4.9.1",
         "semver": "7.5.4",
         "standard-version": "9.5.0",
         "tslib": "2.6.2",


### PR DESCRIPTION
Reverts cthelion9669/paypal-js#2